### PR TITLE
Address Kong Admin token and Kong Admin API key issues

### DIFF
--- a/kong/utils.go
+++ b/kong/utils.go
@@ -78,7 +78,10 @@ func GetKongClient(opt Config) (*kong.Client, error) {
 
 	var headers []string
 	if opt.APIKey != "" {
-		headers = append(headers, fmt.Sprintf("kong-admin-token:%v", opt.APIKey))
+		headers = append(headers, fmt.Sprintf("apikey:%v", opt.APIKey))
+	}
+	if opt.AdminToken != "" {
+		headers = append(headers, fmt.Sprintf("kong-admin-token:%v", opt.AdminToken))
 	}
 	if opt.Username != "" || opt.Password != "" {
 		headers = append(headers, fmt.Sprintf("Authorization: Basic %v", basicAuth(opt.Username, opt.Password)))


### PR DESCRIPTION
Address the following issues:

  1. The Kong Admin token (Kong Enterprise) is not added.
  2. The key authentication credential is not added to the request.

  ---
  If the Kong Admin API is configured with key authentication, the
  credential must be included in the request. Here it is added as a
  header.

  ---
  Also see:
    * https://github.com/kevholditch/terraform-provider-kong/issues/135
    * https://github.com/kevholditch/terraform-provider-kong/pull/140